### PR TITLE
issue #45 詳細ページの下にその公演のコントを追加

### DIFF
--- a/src/components/Controls/SearchBox.jsx
+++ b/src/components/Controls/SearchBox.jsx
@@ -107,6 +107,7 @@ export default function SearchBox({ contMetaData, onSelectContId }) {
                                         className="
                                             w-full px-4 py-3 text-left
                                             hover:bg-gray-50
+                                            cursor-pointer
                                         "
                                     >
                                         <div className="text-sm text-gray-900">

--- a/src/components/Controls/SearchBox.jsx
+++ b/src/components/Controls/SearchBox.jsx
@@ -34,14 +34,18 @@ export default function SearchBox({ contMetaData, onSelectContId }) {
 
     // 外側クリックで閉じる
     useEffect(() => {
-        const onDocMouseDown = (e) => {
+        const onDocPointerDown = (e) => {
+            console.log("doc pointerdown", e.target);
             if (!rootRef.current) return;
             if (!rootRef.current.contains(e.target)) {
                 setOpen(false);
+                setQuery("");
             }
         };
-        document.addEventListener("mousedown", onDocMouseDown);
-        return () => document.removeEventListener("mousedown", onDocMouseDown);
+
+        document.addEventListener("pointerdown", onDocPointerDown, true);
+        return () =>
+            document.removeEventListener("pointerdown", onDocPointerDown, true);
     }, []);
 
     const commitSelect = (c) => {

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -201,6 +201,20 @@ export default function Main() {
         buildGraph({ width, height }).then(setGraph);
     }, []);
 
+    // 同一公演のコント一覧（上演順）
+    const contsInSamePerformance = useMemo(() => {
+        if (!selectedCont?.performanceId) return [];
+
+        return contMetaData
+            .filter(
+                (c) => String(c.performanceId) === String(selectedCont.performanceId)
+            )
+            .sort((a, b) => {
+                // contId は文字列なので数値比較
+                return Number(a.contId) - Number(b.contId);
+            });
+    }, [contMetaData, selectedCont]);
+
     return (
         <div className="relative h-full">
             <div className="pointer-events-none absolute left-0 z-40">
@@ -245,6 +259,8 @@ export default function Main() {
             <DetailContent
                 cont={selectedCont}
                 performanceById={performanceById}
+                contsInSamePerformance={contsInSamePerformance}
+                onSelectContId={selectCont}
                 onClose={() => {
                     setSelectedContId(null);
                     setHighlightedPerformanceId(null);

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -229,16 +229,20 @@ export default function Main() {
                     </div>
 
                     {/* 凡例 */}
-                    <div className="pointer-events-none">
-                        <Legend
-                            performanceMetaData={performanceMetaData}
-                            highlightedPerformanceId={highlightedPerformanceId}
-                            onClickPerformance={(id) => {
-                                setHighlightedPerformanceId((prev) =>
-                                    String(prev) === String(id) ? null : String(id)
-                                );
-                            }}
-                        />
+                    <div className="absolute left-0 top-10 z-40 pointer-events-none">
+                        <div className="px-5 py-5 w-72">
+                            <div className="pointer-events-none">
+                                <Legend
+                                    performanceMetaData={performanceMetaData}
+                                    highlightedPerformanceId={highlightedPerformanceId}
+                                    onClickPerformance={(id) => {
+                                        setHighlightedPerformanceId((prev) =>
+                                            String(prev) === String(id) ? null : String(id)
+                                        );
+                                    }}
+                                />
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -104,11 +104,11 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                     </div>
                 ) : null} */}
 
-                <div className="divider my-4">コント情報</div>
+                <div className="divider my-2">コント情報</div>
 
                 {cont.duration ? (
                     <div className="card bg-base-100">
-                        <div className="card-body p-2">
+                        <div className="card-body p-1">
                             <div className="text-xs text-base-content/60">
                                 時間
                             </div>
@@ -118,7 +118,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                 ) : null}
 
                 <div className="mt-3 card bg-base-100">
-                    <div className="card-body p-2">
+                    <div className="card-body p-1">
                         <div className="text-xs text-base-content/60">
                             小道具
                         </div>
@@ -128,11 +128,11 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                     </div>
                 </div>
 
-                <div className="divider my-4">公演情報</div>
+                <div className="divider my-2">公演情報</div>
 
                 {/* 公演名 */}
                 <div className="card bg-base-100">
-                    <div className="card-body p-2">
+                    <div className="card-body p-1">
                         <div className="text-xs text-base-content/60">
                             公演名
                         </div>
@@ -145,7 +145,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                 {/* 公演年 */}
                 {performanceYear ? (
                     <div className="card bg-base-100">
-                        <div className="card-body p-2">
+                        <div className="card-body p-1">
                             <div className="text-xs text-base-content/60">
                                 公演年
                             </div>
@@ -154,7 +154,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                     </div>
                 ) : (
                     <div className="card bg-base-100">
-                        <div className="card-body p-2">
+                        <div className="card-body p-1">
                             <div className="text-xs text-base-content/60">
                                 公演年
                             </div>
@@ -167,7 +167,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
 
                 {/* この公演で演じられたコント */}
                 <div className="mt-3 card bg-base-100">
-                    <div className="card-body p-2">
+                    <div className="card-body p-1">
                         <div className="text-xs text-base-content/60 mb-1">
                             この公演で演じられたコント
                         </div>
@@ -213,7 +213,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
 
                 {/* 公演都市 */}
                 <div className="mt-3 card bg-base-100">
-                    <div className="card-body p-2">
+                    <div className="card-body p-1">
                         <div className="text-xs text-base-content/60">
                             公演都市
                         </div>
@@ -225,7 +225,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
 
                 {/* 公演DVD（URL） */}
                 <div className="mt-3 card bg-base-100 ">
-                    <div className="card-body p-3">
+                    <div className="card-body p-1">
                         <div className="text-xs text-base-content/60">
                             公演DVD
                         </div>

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -166,7 +166,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                 )}
 
                 {/* この公演で演じられたコント */}
-                <div className="mt-3 card bg-base-100">
+                <div className="card bg-base-100">
                     <div className="card-body p-1">
                         <div className="text-xs text-base-content/60 mb-1">
                             この公演で演じられたコント
@@ -232,7 +232,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
 
                         {performanceUrl ? (
                             <a
-                                className="link link-primary break-all"
+                                className="link link-primary break-all cursor-pointer"
                                 href={performanceUrl}
                                 target="_blank"
                                 rel="noreferrer"

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { CONT_ID_TO_COLOR } from "../../lib/getContNodeClass";
 
 function toYouTubeEmbedUrl(url) {
     if (!url) return null;
@@ -44,14 +44,27 @@ export default function DetailContent({
     const performanceCityRaw = perf?.performanceCity ?? "";
     const performanceUrl = perf?.url ?? "";
 
+    const perfId =
+        cont.performanceId != null ? Number(cont.performanceId) : null;
+    const perfColor = perfId != null ? CONT_ID_TO_COLOR[perfId] : null;
+
     return (
         <aside className="absolute top-0 right-0 z-50 h-screen w-[360px] bg-base-100 shadow-2xl flex flex-col">
             {/* header */}
             <div className="p-4 border-base-200 flex items-start gap-3">
                 <div className="flex-1 min-w-0">
-                    <h1 className="text-sm text-base-content/60 break-words">
-                        {performanceName || "（公演名不明）"}
-                    </h1>
+                    {/* ★ 変更：公演名行に色ドットを追加 */}
+                    <div className="flex items-center gap-2 min-w-0">
+                        <span
+                            className="inline-block h-2 w-2 rounded-full shrink-0"
+                            style={{ backgroundColor: perfColor ?? "#9CA3AF" }} // fallback: gray-400
+                            aria-hidden="true"
+                        />
+                        <h1 className="text-sm text-base-content/60 break-words">
+                            {performanceName || "（公演名不明）"}
+                        </h1>
+                    </div>
+
                     <h2 className="mt-1 text-base font-semibold break-words">
                         {cont.title}
                     </h2>

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -49,6 +49,9 @@ export default function DetailContent({
             {/* header */}
             <div className="p-4 border-base-200 flex items-start gap-3">
                 <div className="flex-1 min-w-0">
+                    <h1 className="text-sm text-base-content/60 break-words">
+                        {performanceName || "（公演名不明）"}
+                    </h1>
                     <h2 className="mt-1 text-base font-semibold break-words">
                         {cont.title}
                     </h2>
@@ -134,19 +137,54 @@ export default function DetailContent({
                     </div>
                 </div>
 
-                <div className="divider my-2">公演情報</div>
+                <div className="divider my-2">同じ公演のコント</div>
 
-                {/* 公演名 */}
-                <div className="card bg-base-100">
+                {/* この公演で演じられたコント */}
+                <div className="mt-1 card bg-base-100">
                     <div className="card-body p-1">
-                        <div className="text-xs text-base-content/60">
-                            公演名
-                        </div>
-                        <div className="text-sm break-words">
-                            {performanceName || "情報がありません"}
-                        </div>
+                        {contsInSamePerformance?.length ? (
+                            <ul className="space-y-1">
+                                {contsInSamePerformance.map((c, index) => {
+                                    const isCurrent = c.contId === cont.contId;
+                                    const order = index + 1;
+
+                                    return (
+                                        <li key={c.contId}>
+                                            <button
+                                                type="button"
+                                                disabled={isCurrent}
+                                                onClick={() =>
+                                                    onSelectContId?.(c.contId)
+                                                }
+                                                className={`w-full text-left flex gap-2 rounded px-1 py-0.5 text-sm break-words ${
+                                                    isCurrent
+                                                        ? "font-semibold text-primary cursor-default"
+                                                        : "hover:bg-base-200 text-base-content cursor-pointer"
+                                                }`}
+                                            >
+                                                {/* 公演内番号 */}
+                                                <span className="tabular-nums text-base-content/60">
+                                                    {order}.
+                                                </span>
+
+                                                {/* コント名 */}
+                                                <span className="flex-1">
+                                                    {c.title}
+                                                </span>
+                                            </button>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        ) : (
+                            <div className="text-sm text-base-content/60">
+                                情報がありません
+                            </div>
+                        )}
                     </div>
                 </div>
+
+                <div className="divider my-2">公演情報</div>
 
                 {/* 公演年 */}
                 {performanceYear ? (
@@ -203,58 +241,6 @@ export default function DetailContent({
                                 情報がありません
                             </div>
                         )}
-
-                        <div className="divider my-2">この公演のコント</div>
-
-                        {/* この公演で演じられたコント */}
-                        <div className="mt-1 card bg-base-100">
-                            <div className="card-body p-1">
-                                {contsInSamePerformance?.length ? (
-                                    <ul className="space-y-1">
-                                        {contsInSamePerformance.map(
-                                            (c, index) => {
-                                                const isCurrent =
-                                                    c.contId === cont.contId;
-                                                const order = index + 1;
-
-                                                return (
-                                                    <li key={c.contId}>
-                                                        <button
-                                                            type="button"
-                                                            disabled={isCurrent}
-                                                            onClick={() =>
-                                                                onSelectContId?.(
-                                                                    c.contId
-                                                                )
-                                                            }
-                                                            className={`w-full text-left flex gap-2 rounded px-1 py-0.5 text-sm break-words ${
-                                                                isCurrent
-                                                                    ? "font-semibold text-primary cursor-default"
-                                                                    : "hover:bg-base-200 text-base-content cursor-pointer"
-                                                            }`}
-                                                        >
-                                                            {/* 公演内番号 */}
-                                                            <span className="tabular-nums text-base-content/60">
-                                                                {order}.
-                                                            </span>
-
-                                                            {/* コント名 */}
-                                                            <span className="flex-1">
-                                                                {c.title}
-                                                            </span>
-                                                        </button>
-                                                    </li>
-                                                );
-                                            }
-                                        )}
-                                    </ul>
-                                ) : (
-                                    <div className="text-sm text-base-content/60">
-                                        情報がありません
-                                    </div>
-                                )}
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -158,7 +158,7 @@ export default function DetailContent({
                                                 }
                                                 className={`w-full text-left flex gap-2 rounded px-1 py-0.5 text-sm break-words ${
                                                     isCurrent
-                                                        ? "font-semibold text-primary cursor-default"
+                                                        ? "text-base-content/40 cursor-default"
                                                         : "hover:bg-base-200 text-base-content cursor-pointer"
                                                 }`}
                                             >

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -43,10 +43,6 @@ export default function DetailContent({ cont, performanceById, onClose }) {
             {/* header */}
             <div className="p-4 border-base-200 flex items-start gap-3">
                 <div className="flex-1 min-w-0">
-                    <h1 className="text-sm text-base-content/60 break-words">
-                        {performanceName || "（公演名不明）"}
-                    </h1>
-
                     <h2 className="mt-1 text-base font-semibold break-words">
                         {cont.title}
                     </h2>
@@ -133,6 +129,18 @@ export default function DetailContent({ cont, performanceById, onClose }) {
                 </div>
 
                 <div className="divider my-4">公演情報</div>
+
+                {/* 公演名 */}
+                <div className="card bg-base-100">
+                    <div className="card-body p-2">
+                        <div className="text-xs text-base-content/60">
+                            公演名
+                        </div>
+                        <div className="text-sm break-words">
+                            {performanceName || "情報がありません"}
+                        </div>
+                    </div>
+                </div>
 
                 {/* 公演年 */}
                 {performanceYear ? (

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -24,7 +24,7 @@ function toYouTubeEmbedUrl(url) {
     }
 }
 
-export default function DetailContent({ cont, performanceById, onClose }) {
+export default function DetailContent({ cont, performanceById, contsInSamePerformance, onSelectContId, onClose, }) {
     if (!cont) return null;
 
     const perf = cont.performanceId
@@ -164,6 +164,52 @@ export default function DetailContent({ cont, performanceById, onClose }) {
                         </div>
                     </div>
                 )}
+
+                {/* この公演で演じられたコント */}
+                <div className="mt-3 card bg-base-100">
+                    <div className="card-body p-2">
+                        <div className="text-xs text-base-content/60 mb-1">
+                            この公演で演じられたコント
+                        </div>
+
+                        {contsInSamePerformance?.length ? (
+                            <ul className="space-y-1">
+                                {contsInSamePerformance.map((c, index) => {
+                                    const isCurrent = c.contId === cont.contId;
+                                    const order = index + 1;
+
+                                    return (
+                                        <li key={c.contId}>
+                                            <button
+                                                type="button"
+                                                disabled={isCurrent}
+                                                onClick={() => onSelectContId?.(c.contId)}
+                                                className={`w-full text-left flex gap-2 rounded px-1 py-0.5 text-sm break-words ${isCurrent
+                                                    ? "font-semibold text-primary cursor-default"
+                                                    : "hover:bg-base-200 text-base-content cursor-pointer"
+                                                    }`}
+                                            >
+                                                {/* 公演内番号 */}
+                                                <span className="tabular-nums text-base-content/60">
+                                                    {order}.
+                                                </span>
+
+                                                {/* コント名 */}
+                                                <span className="flex-1">
+                                                    {c.title}
+                                                </span>
+                                            </button>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        ) : (
+                            <div className="text-sm text-base-content/60">
+                                情報がありません
+                            </div>
+                        )}
+                    </div>
+                </div>
 
                 {/* 公演都市 */}
                 <div className="mt-3 card bg-base-100">

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -166,7 +166,7 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                 )}
 
                 {/* この公演で演じられたコント */}
-                <div className="card bg-base-100">
+                <div className="mt-1 card bg-base-100">
                     <div className="card-body p-1">
                         <div className="text-xs text-base-content/60 mb-1">
                             この公演で演じられたコント

--- a/src/components/detail/DetailContent.jsx
+++ b/src/components/detail/DetailContent.jsx
@@ -24,7 +24,13 @@ function toYouTubeEmbedUrl(url) {
     }
 }
 
-export default function DetailContent({ cont, performanceById, contsInSamePerformance, onSelectContId, onClose, }) {
+export default function DetailContent({
+    cont,
+    performanceById,
+    contsInSamePerformance,
+    onSelectContId,
+    onClose,
+}) {
     if (!cont) return null;
 
     const perf = cont.performanceId
@@ -164,53 +170,6 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                         </div>
                     </div>
                 )}
-
-                {/* この公演で演じられたコント */}
-                <div className="mt-1 card bg-base-100">
-                    <div className="card-body p-1">
-                        <div className="text-xs text-base-content/60 mb-1">
-                            この公演で演じられたコント
-                        </div>
-
-                        {contsInSamePerformance?.length ? (
-                            <ul className="space-y-1">
-                                {contsInSamePerformance.map((c, index) => {
-                                    const isCurrent = c.contId === cont.contId;
-                                    const order = index + 1;
-
-                                    return (
-                                        <li key={c.contId}>
-                                            <button
-                                                type="button"
-                                                disabled={isCurrent}
-                                                onClick={() => onSelectContId?.(c.contId)}
-                                                className={`w-full text-left flex gap-2 rounded px-1 py-0.5 text-sm break-words ${isCurrent
-                                                    ? "font-semibold text-primary cursor-default"
-                                                    : "hover:bg-base-200 text-base-content cursor-pointer"
-                                                    }`}
-                                            >
-                                                {/* 公演内番号 */}
-                                                <span className="tabular-nums text-base-content/60">
-                                                    {order}.
-                                                </span>
-
-                                                {/* コント名 */}
-                                                <span className="flex-1">
-                                                    {c.title}
-                                                </span>
-                                            </button>
-                                        </li>
-                                    );
-                                })}
-                            </ul>
-                        ) : (
-                            <div className="text-sm text-base-content/60">
-                                情報がありません
-                            </div>
-                        )}
-                    </div>
-                </div>
-
                 {/* 公演都市 */}
                 <div className="mt-3 card bg-base-100">
                     <div className="card-body p-1">
@@ -244,6 +203,58 @@ export default function DetailContent({ cont, performanceById, contsInSamePerfor
                                 情報がありません
                             </div>
                         )}
+
+                        <div className="divider my-2">この公演のコント</div>
+
+                        {/* この公演で演じられたコント */}
+                        <div className="mt-1 card bg-base-100">
+                            <div className="card-body p-1">
+                                {contsInSamePerformance?.length ? (
+                                    <ul className="space-y-1">
+                                        {contsInSamePerformance.map(
+                                            (c, index) => {
+                                                const isCurrent =
+                                                    c.contId === cont.contId;
+                                                const order = index + 1;
+
+                                                return (
+                                                    <li key={c.contId}>
+                                                        <button
+                                                            type="button"
+                                                            disabled={isCurrent}
+                                                            onClick={() =>
+                                                                onSelectContId?.(
+                                                                    c.contId
+                                                                )
+                                                            }
+                                                            className={`w-full text-left flex gap-2 rounded px-1 py-0.5 text-sm break-words ${
+                                                                isCurrent
+                                                                    ? "font-semibold text-primary cursor-default"
+                                                                    : "hover:bg-base-200 text-base-content cursor-pointer"
+                                                            }`}
+                                                        >
+                                                            {/* 公演内番号 */}
+                                                            <span className="tabular-nums text-base-content/60">
+                                                                {order}.
+                                                            </span>
+
+                                                            {/* コント名 */}
+                                                            <span className="flex-1">
+                                                                {c.title}
+                                                            </span>
+                                                        </button>
+                                                    </li>
+                                                );
+                                            }
+                                        )}
+                                    </ul>
+                                ) : (
+                                    <div className="text-sm text-base-content/60">
+                                        情報がありません
+                                    </div>
+                                )}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### やったこと
- 詳細ページヘッダーの公演名を下に移動した
- 公演情報にその公演のコント一覧を追加
- コント一覧からコントをクリックするとそのコントを選択できる
- スクロールにならないように縦の幅を調整した(全体的に狭くなってる
- ついでに一番下のリンクのカーソルをpointerに直した

---

### 追加でやったこと
- 検索のサジェストのカーソルをpointerにした
- 検索ボックスになんか入力されてる時に外をクリックしたらその入力が消えるようにした
- ↑は前はできてた気がしたけど気づいたら出来なくなってたので直した

<img width="1713" height="1000" alt="スクリーンショット 2026-01-25 4 21 58" src="https://github.com/user-attachments/assets/ca24f7d4-74e6-4de9-95ea-e81deb7064bf" />
)